### PR TITLE
Fix #1

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -15,5 +15,6 @@ function temp_instead_function($args) {
   if ($code != 302) {
     // Redirect with 302 instead
     yourls_redirect($url,302);
+    die();
   }
 }


### PR DESCRIPTION
Add die() after redirect so the normal flow of events is interrupted.

When I first installed YOURLS a year or two ago I installed this plugin but found it didn't work (or perhaps it stopped working after an update, I can't fully remember). Adding this die() function after the redirect resolved the issue and it's been running fine for me ever since. Unfortunately, I failed to submit a PR at the time. Issue #1 reminded me.